### PR TITLE
Fix get_companies

### DIFF
--- a/sharesies/client.py
+++ b/sharesies/client.py
@@ -213,9 +213,9 @@ class Client:
             'https://data.sharesies.nz/api/v1/instruments?Page='+str(page)+'&PerPage=500&Sort=marketCap&PriceChangeTime=1y&Query='
         )
 
-        filtered_data = [item for item in r.json()["instruments"] if item["instrumentType"] == "equity"]
+        companies = [item for item in r.json()["instruments"] if item["instrumentType"] == "equity"]
 
-        return filtered_data
+        return companies
 
     def get_info(self):
         '''

--- a/sharesies/client.py
+++ b/sharesies/client.py
@@ -201,18 +201,21 @@ class Client:
 
         return r.json()['dayPrices']
 
-    def get_companies(self):
+    def get_companies(self, page=1):
         '''
-        Returns all companies accessible through Sharesies
+        Gets a certain page of companies
         '''
+
+        headers = self.session.headers
+        headers['Authorization'] = f'Bearer {self.auth_token}'
 
         r = self.session.get(
-            'https://app.sharesies.nz/api/fund/list'
+            'https://data.sharesies.nz/api/v1/instruments?Page='+str(page)+'&PerPage=500&Sort=marketCap&PriceChangeTime=1y&Query='
         )
 
-        funds = r.json()['funds']
+        filtered_data = [item for item in r.json()["instruments"] if item["instrumentType"] == "equity"]
 
-        return [fund for fund in funds if fund['fund_type'] == 'company']
+        return filtered_data
 
     def get_info(self):
         '''


### PR DESCRIPTION
It appears that Sharesies no longer exposes app.sharesies.nz/api/fund/list so I have reworked the logic of get_companies to instead get all instruments and filter out etfs and other stocks.

Shouldn't be a breaking change, as the method/endpoint wasn't working anyway. Same function call will work.

Closes #18 