### PR TITLE
Add ability to create and update auto invests

### DIFF
--- a/sharesies/client.py
+++ b/sharesies/client.py
@@ -285,6 +285,39 @@ class Client:
         )
 
         return r.status_code == 200
+    
+    def auto_invest_create(self, amount, interval, start, companies, percentages, order_name):
+        '''
+        Create an auto invest order
+        
+        func params:
+            amount: amount in NZ dollars
+            interval: auto invest interval ("1week", "2week", "4week", "1month")
+            start: date of start ("YYYY-MM-DD")
+            companies: array of companies to auto invest in
+            percentages: array of percentages corresponding with the company in the same array index
+            order_name: name of the order
+        '''
+        
+        self.reauth() # Avoid timeout
+        
+        allocations = [{"fund_id": company['id'], "allocation": str(percentage)} for company, percentage in zip(companies, percentages)]
+        
+        auto_invest_info = {
+            'acting_as_id': self.user_id,
+            'amount': amount,
+            'interval': interval,
+            'start': start,
+            'allocations': allocations,
+            'order_name': order_name,   
+        }
+        
+        r = self.session.post(
+            'https://app.sharesies.com/api/autoinvest/set-diy-order',
+            json=auto_invest_info
+        )
+        
+        return r.status_code == 200
 
     def sell(self, company, shares):
         '''

--- a/sharesies/client.py
+++ b/sharesies/client.py
@@ -313,7 +313,7 @@ class Client:
         }
         
         r = self.session.post(
-            'https://app.sharesies.com/api/autoinvest/set-diy-order',
+            'https://app.sharesies.nz/api/autoinvest/set-diy-order',
             json=auto_invest_info
         )
         

--- a/sharesies/client.py
+++ b/sharesies/client.py
@@ -318,6 +318,41 @@ class Client:
         )
         
         return r.status_code == 200
+    
+    def auto_invest_update(self, order_id, amount, interval, start, companies, percentages, order_name):
+        '''
+        Create an auto invest order
+        
+        func params:
+            id: existing auto invest id
+            amount: amount in NZ dollars
+            interval: auto invest interval ("1week", "2week", "4week", "1month")
+            start: date of start ("YYYY-MM-DD")
+            companies: array of companies to auto invest in
+            percentages: array of percentages corresponding with the company in the same array index
+            order_name: name of the order
+        '''
+        
+        self.reauth() # Avoid timeout
+        
+        allocations = [{"fund_id": company['id'], "allocation": str(percentage)} for company, percentage in zip(companies, percentages)]
+        
+        auto_invest_info = {
+            'acting_as_id': self.user_id,
+            'amount': amount,
+            'interval': interval,
+            'order_id': order_id,
+            'start': start,
+            'allocations': allocations,
+            'order_name': order_name,   
+        }
+        
+        r = self.session.post(
+            'https://app.sharesies.nz/api/autoinvest/set-diy-order',
+            json=auto_invest_info
+        )
+        
+        return r.status_code == 200
 
     def sell(self, company, shares):
         '''

--- a/sharesies/client.py
+++ b/sharesies/client.py
@@ -289,14 +289,6 @@ class Client:
     def auto_invest_create(self, amount, interval, start, companies, percentages, order_name):
         '''
         Create an auto invest order
-        
-        func params:
-            amount: amount in NZ dollars
-            interval: auto invest interval ("1week", "2week", "4week", "1month")
-            start: date of start ("YYYY-MM-DD")
-            companies: array of companies to auto invest in
-            percentages: array of percentages corresponding with the company in the same array index
-            order_name: name of the order
         '''
         
         self.reauth() # Avoid timeout
@@ -321,16 +313,7 @@ class Client:
     
     def auto_invest_update(self, order_id, amount, interval, start, companies, percentages, order_name):
         '''
-        Create an auto invest order
-        
-        func params:
-            id: existing auto invest id
-            amount: amount in NZ dollars
-            interval: auto invest interval ("1week", "2week", "4week", "1month")
-            start: date of start ("YYYY-MM-DD")
-            companies: array of companies to auto invest in
-            percentages: array of percentages corresponding with the company in the same array index
-            order_name: name of the order
+        Update an existing auto invest order
         '''
         
         self.reauth() # Avoid timeout


### PR DESCRIPTION
Added two new functions:

auto_invest_create - allows users to add a new auto-invest scheme.
params:
```
amount: amount in NZ dollars
interval: auto invest interval ("1week", "2week", "4week", "1month")
start: date of start ("YYYY-MM-DD")
companies: array of companies to auto invest in
percentages: array of percentages corresponding with the company in the same array index
order_name: name of the order
```
Example usage: 
```
instruments = client.get_instruments(1)
apple = instruments['instruments'][0]
microsoft = instruments['instruments'][1]
autoinvest = client.auto_invest_create(100, '1week', '2024-10-05', [apple, microsoft], [33, 67], 'new auto invest')
```
This will create a new autoinvest with apple and microsoft, with apple at 33% and microsoft at 67%.

auto_invest_update - allows users to update their existing auto-invest scheme.
params are the same as above, except the first param is the id of the existing scheme

Example usage:
```
instruments = client.get_instruments(1)
apple = instruments['instruments'][0]
microsoft = instruments['instruments'][1]
autoinvest = client.auto_invest_update('eb130729-2d34-42f5-b661-2df578bd97b1',  100, '1week', '2024-10-05', [apple, microsoft], [50, 50], 'updated auto invest')
```
This will update the existing autoinvest, changing the name to "updated auto invest" and the companies to be 50% 50%.

