### PR TITLE
Added ability to get weekly top 10 

### DIFF
--- a/sharesies/client.py
+++ b/sharesies/client.py
@@ -151,6 +151,28 @@ class Client:
             current['priceHistory'] = self.get_price_history(id_)
 
         return responce
+    
+    def get_weekly_top_ten(self, index=None):
+        '''
+        Get the weekly top ten funds.
+        If index is None, returns all fund IDs.
+        Otherwise, returns the fund ID at the specified index.
+        '''
+
+        if index is not None and (index < 0 or index >= 10):
+            raise IndexError("Index out of range. Please provide an index between 0 and 10")
+
+        r = self.session.get(
+            'https://app.sharesies.nz/api/explore/weekly-top-ten-funds',
+        )
+        
+        response = r.json()
+        fund_ids = response['fund_ids']
+
+        if index is not None:
+            return fund_ids[index]
+
+        return fund_ids  # Return all fund IDs if index is None
 
     def get_instrument(self, fund_id):
         '''


### PR DESCRIPTION
Added new function:

get_weekly_top_10 - allows the user to get the ids of the shares in the weekly top ten.

This can be used in two different ways:
No params:
```
topten = client.get_weekly_top_ten()
```
This will return an array containing the ids of the top 10 shares
Example output:
```
['af87fb44-ebf6-4239-ba08-ae1cc9a6461c', '77866efa-d81e-4f71-beaf-371bb210ac8c', '67a17798-c341-4af3-a06e-5a621d342adb', '68d32bbf-13e7-46e3-b735-1a7bb91ad481', '8cd3115a-831b-4a5a-9cdd-a5d523c6814f', '65cec97c-c39f-4aa3-b8e7-b24599d88c33', '84fb0b94-e7dd-4a48-996d-fd261b781c11', '5e2edbf1-4b44-4a6f-8b2e-d2c1c752be79', 'cb92e6bd-d599-4872-bb7c-1d4d2d-d599-4872-bb7c-1d4d24582854', '9fa9f8dc-c1f7-4afc-8433-a0e2a761b570']
```

Index param:
```
third = client.get_weekly_top_ten(2)
```
This will return a single id, representing the third (index 2 out of 9) id in the top 10 shares array
Example output:
```
67a17798-c341-4af3-a06e-5a621d342adb
```